### PR TITLE
Fixed normalize.css is not installed via npm install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/netzstrategen/bacon.git"
   },
   "private": true,
+  "dependencies": {
+    "normalize.css": "~7.0.0"
+  },
   "devDependencies": {
     "gulp": "~3.9.1",
     "gulp-autoprefixer": "~4.0.0",
@@ -22,7 +25,6 @@
     "gulp-sass": "~3.1.0",
     "gulp-sourcemaps": "~2.6.0",
     "gulp-stylelint": "~3.9.0",
-    "normalize.css": "~7.0.0",
     "sassdoc": "^2.3.0",
     "stylelint": "~7.13.0",
     "stylelint-order": "~0.5.0",


### PR DESCRIPTION
Dev dependencies are not installed when running npm install from a parent level. In order to fix this I moved it to the regular dependencies key as it is mandatory for the framework.