### PR TITLE
Renamed media object to avoid class name clashes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/bacon",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "title": "Bacon",
   "description": "netzstrategen baseline CSS framework",
   "homepage": "http://www.netzstrategen.com",

--- a/src/utilities/_objects.media.scss
+++ b/src/utilities/_objects.media.scss
@@ -6,16 +6,16 @@
 $media-object-spacing: $global-spacing-unit !default;
 
 
-.media {
+.o-media {
   display: flex;
   align-items: flex-start;
 }
 
-.media__figure {
+.o-media__figure {
   margin-right: $media-object-spacing;
 }
 
-.media__body {
+.o-media__body {
   flex: 1;
 }
 
@@ -24,10 +24,10 @@ $media-object-spacing: $global-spacing-unit !default;
  * Reverse media object (image on right)
  */
 
-.media--rev {
+.o-media--rev {
   align-items: flex-end;
 
-  .media__figure {
+  .o-media__figure {
     margin-right: 0;
     margin-left: $media-object-spacing;
   }


### PR DESCRIPTION
Added namespace to media object as Drupal uses .media as a generic wrapper for media library items.

`.o-` namespacing is used in several popular libraries including [Inuit](https://github.com/inuitcss/inuitcss/blob/develop/objects/_objects.media.scss).