### PR TITLE
Fixed line-height unit check in font-size mixin.

### DIFF
--- a/src/tools/_mixin.font-size.scss
+++ b/src/tools/_mixin.font-size.scss
@@ -25,11 +25,13 @@
 
   font-size: ($font-size / $global-font-size) * 1rem $important;
 
-  @if (type-of($line-height) == number or $line-height == 'inherit' or $line-height == 'normal') {
-    line-height: $line-height $important;
-  } @else if (unit($line-height) == "px") {
-    $line-height: $line-height / $font-size;
-  } @else {
+  @if (type-of($line-height) == number) {
+    @if (unit($line-height) == "px") {
+      $line-height: $line-height / $font-size;
+    }
+  } @else if not($line-height == 'inherit' or $line-height == 'normal') {
     @error "`#{$line-height}` is not a valid value for `$line-height`.";
   }
+
+  line-height: $line-height $important;
 }


### PR DESCRIPTION
Previously, if non-unit value (`inherit`, `normal`) was sent through using the `@include font-size()` mixin then it would error. Fixed the conditional so it sets and fails correctly.