### PR TITLE
Removed buggy and unnecessary merge of colour maps.

### DIFF
--- a/src/_config/_config.core.scss
+++ b/src/_config/_config.core.scss
@@ -5,8 +5,7 @@
 
 // Colours
 
-$global-colors: () !default;
-$global-colors: map-merge((
+$global-colors: (
   brand: (
     base: #1796e1,
     secondary: #1bb2fe,
@@ -35,7 +34,7 @@ $global-colors: map-merge((
     success: #8df0bb,
     error: #fec9c8
   )
-), $global-colors);
+) !default;
 
 
 /// Grabs colors from the map using `color(brand, secondary)` or `color(brand)`.


### PR DESCRIPTION
When used with the NEPO sub-themes, the map-merge of $global-colours causes compilation issues.
We don't really need to share colours across themes so just define it as a variable.