### PR TITLE
Fixed mixin font-size 'normal' default parameters was invalid because…

### DIFF
--- a/src/tools/_mixin.font-size.scss
+++ b/src/tools/_mixin.font-size.scss
@@ -37,5 +37,5 @@
     @error "`#{$line-height}` is not a valid value for `$line-height`.";
   }
 
-  line-height: $line-height $important;
+  line-height: unquote($line-height) $important;
 }


### PR DESCRIPTION
… was wrapped in quotes.

This fix is necessary because, without, the default parameter `normal` became an invalid `"normal"`.