### PR TITLE
Added mixin to break longer words.

### DIFF
--- a/src/bacon.scss
+++ b/src/bacon.scss
@@ -5,6 +5,7 @@
 @import
   '_config/config.core',
 
+  'tools/mixin.break-word',
   'tools/mixin.clearfix',
   'tools/mixin.font-size',
   'tools/mixin.hocus',

--- a/src/tools/_mixin.break-word.scss
+++ b/src/tools/_mixin.break-word.scss
@@ -1,0 +1,12 @@
+///
+/// Break longer words onto a new line. Add hyphen where browser supports.
+/// https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
+///
+
+@mixin break-word() {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-all;
+  word-break: break-word;
+  hyphens: auto;
+}


### PR DESCRIPTION
Where word is bigger than it's container, break to new line and add a hyphen (where supported).

To replace mixin added manually to NEPO here - https://github.com/netzstrategen/nepo/pull/104/commits/1259724b49573b6d1a9d5c1f2d0deac0b8745335. This code will now be removed from that commit.