### PR TITLE
Fixed break-word IE/Edge bug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/bacon",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "title": "Bacon",
   "description": "netzstrategen baseline CSS framework",
   "homepage": "http://www.netzstrategen.com",

--- a/src/tools/_mixin.break-word.scss
+++ b/src/tools/_mixin.break-word.scss
@@ -6,7 +6,6 @@
 @mixin break-word() {
   overflow-wrap: break-word;
   word-wrap: break-word;
-  word-break: break-all;
   word-break: break-word;
   hyphens: auto;
 }


### PR DESCRIPTION
Previous word-break duplication was breaking hyphens in IE/Edge.