### PR TITLE
Changed node_modules import to allow multiple outputs.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,13 +2,13 @@ const autoprefixer = require('gulp-autoprefixer');
 const cleanCss = require('gulp-clean-css');
 const gulp = require('gulp');
 const gulpif = require('gulp-if');
+const magicImporter = require('node-sass-magic-importer');
 const pkg = require('./package.json');
 const plumber = require('gulp-plumber');
 const rename = require('gulp-rename');
 const replace = require('gulp-replace');
 const sass = require('gulp-sass');
 const sassdoc = require('sassdoc');
-const sassModuleImporter = require('sass-module-importer');
 const sourcemaps = require('gulp-sourcemaps');
 const stylelint = require('gulp-stylelint');
 
@@ -48,7 +48,9 @@ const cssTasks = function(filename, options = { outputStyle: 'nested', sourcemap
     }))
     .pipe(gulpif(options.sourcemaps, sourcemaps.init()))
     .pipe(sass({
-      importer: sassModuleImporter(),
+      importer: magicImporter({
+        disableImportOnce: true
+      }),
       outputStyle: options.outputStyle
     }).on('error', sass.logError))
     .pipe(autoprefixer(pkg.browserslist))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/bacon",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "title": "Bacon",
   "description": "netzstrategen baseline CSS framework",
   "homepage": "http://www.netzstrategen.com",
@@ -26,8 +26,8 @@
     "gulp-sass": "~3.1.0",
     "gulp-sourcemaps": "~2.6.0",
     "gulp-stylelint": "~3.9.0",
+    "node-sass-magic-importer": "^5.2.0",
     "sassdoc": "^2.3.0",
-    "sass-module-importer": "^1.4.0",
     "stylelint": "~7.13.0",
     "stylelint-order": "~0.5.0",
     "stylelint-scss": "~1.5.1",

--- a/src/_config/_config.core.scss
+++ b/src/_config/_config.core.scss
@@ -93,7 +93,7 @@ $global-transition: 0.1s ease-in-out !default;
 
 // Sass-mq settings
 
-$mq-base-font-size: $global-font-size;
+$mq-base-font-size: $global-font-size !default;
 
 $global-breakpoints: () !default;
 $global-breakpoints: map-merge((

--- a/src/bacon.scss
+++ b/src/bacon.scss
@@ -9,9 +9,9 @@
   'tools/mixin.clearfix',
   'tools/mixin.font-size',
   'tools/mixin.hocus',
-  'sass-mq',
+  '~sass-mq',
 
-  'normalize.css',
+  '~normalize.css/normalize',
 
   'base/reset',
   'base/document',


### PR DESCRIPTION
Related to [PR for gulp-task-collection repo](https://github.com/netzstrategen/gulp-task-collection/pull/10).

Bacon uses the same module importer plugin so this needs to be updated to match the gulp repo (as well as the `~` in front of `node_modules` packages).