### PR TITLE
Fixed form inputs do not inherit font-family of body.

### DIFF
--- a/src/base/forms/_settings.forms.scss
+++ b/src/base/forms/_settings.forms.scss
@@ -35,6 +35,7 @@ $input-shadow-focus: $input-shadow !default;
   appearance: none;
   background-color: $input-background;
   box-shadow: $input-shadow;
+  font: inherit;
   font-size: $input-font-size;
   line-height: $input-line-height;
   // transition: border $input-transition;


### PR DESCRIPTION
### Description
- `normalize.css` sets `font-family: sans-serif` on all `<input>`s which overrides any `font-family` set on the body.
